### PR TITLE
Improve prep_local_windows.ps1 and build_local_windows.ps1 scripts

### DIFF
--- a/build_local_windows.ps1
+++ b/build_local_windows.ps1
@@ -1,10 +1,12 @@
 #!/usr/bin/pwsh
 #
 # Simple helper script to do a full local  build
+$ErrorActionPreference = "Stop"
 
 # Fail quickly if docker isn't working / up
-docker ps
+docker ps 2>&1 > $null
 if ( $LASTEXITCODE -ne 0 ) {
+    Write-Output "ERROR: Docker is not installed or not present in the PATH"
     exit -1
 }
 
@@ -14,7 +16,9 @@ if ( ! $tmpdir ) {
 }
 
 # Cleanup from previous build
-remove-item -recurse -ErrorAction SilentlyContinue "$tmpdir/dcos_build_venv" > $null
+if( Test-Path "$tmpdir/dcos_build_venv" ) {
+    Remove-Item -Recurse -Force "$tmpdir/dcos_build_venv"
+}
 
 # Force Python stdout/err to be unbuffered.
 $env:PYTHONUNBUFFERED="notempty"
@@ -32,17 +36,37 @@ options: `
   preferred: local `
   cloudformation_s3_url: https://s3-us-west-2.amazonaws.com/downloads.dcos.io/dcos"
 
-   $config_yaml | Set-Content -Path "dcos-release.config.yaml" 
+   $config_yaml | Set-Content -Path "dcos-release.config.yaml"
 }
 
 # Create a python virtual environment to install the DC/OS tools to
 python -m venv "$tmpdir/dcos_build_venv"
+if( $LASTEXITCODE -ne 0 ) {
+    Write-Output "ERROR: Cannot create dcos_build_venv"
+    exit 1
+}
 . "$tmpdir/dcos_build_venv/Scripts/Activate.ps1"
+if( $LASTEXITCODE -ne 0 ) {
+    Write-Output "ERROR: Cannot activate dcos_build_venv"
+    exit 1
+}
 
 pip install botocore
+if( $LASTEXITCODE -ne 0 ) {
+    Write-Output "ERROR: Cannot install botocore via pip"
+    exit 1
+}
 
 # Install the DC/OS tools
 ./prep_local_windows.ps1
+if( $LASTEXITCODE -ne 0 ) {
+    Write-Output "ERROR: Failed to run prep_local_windows.ps1"
+    exit 1
+}
 
 # Build a release of DC/OS
 release create $env:USERNAME local_build windows windows.installer
+if ( $LASTEXITCODE -ne 0 ) {
+    Write-Output "ERROR: Failed to create the DC/OS release"
+    exit 1
+}

--- a/prep_local_windows.ps1
+++ b/prep_local_windows.ps1
@@ -4,13 +4,23 @@
 #
 # Expects that it is being run inside of a virtual environment.
 #
+$ErrorActionPreference = "Stop"
 
 if (!$env:VIRTUAL_ENV) {
-   throw "Must be run in a python virtual environment"
+   Write-Output "ERROR: Must be run in a python virtual environment. env:VIRTUAL_ENV is not set"
+   exit 1
 }
 
 # Install the latest version of pip
-python -m pip install -U pip
+python -m pip install -U pip
+if( $LASTEXITCODE -ne 0 ) {
+    Write-Output "ERROR: Failed to upgrade pip"
+    exit 1
+}
 
 # Install the packages in editable mode to the virtual environment.
 pip install -e $PWD
+if( $LASTEXITCODE -ne 0 ) {
+    Write-Output "ERROR: Failed to install the packages into the virtual environment"
+    exit 1
+}


### PR DESCRIPTION
Improvements for `prep_local_windows.ps1` :

* Set `$ErrorActionPreference` to `Stop`
* Use `exit 1` instead of `throw` to allow consistency for error checking for anyone calling the current script
* Add missing error checks to `$LASTEXITCODE`

Improvements for `build_local_windows.ps1`:

* Set `$ErrorActionPreference` to `Stop`
* Add relevant error message if Docker is not working / running
* Do previous build cleanup only if the directory is present, and make it fatal in order to avoid potential issues if the other build is not succesfully cleaned-up
* Remove extra space
* Add missing error checks for `$LASTEXITCODE`
