### PR TITLE
Add '-ErrorAction Stop' to Resolve-DnsName

### DIFF
--- a/packages/dcos-net/extra/gen_resolvconf.ps1
+++ b/packages/dcos-net/extra/gen_resolvconf.ps1
@@ -18,7 +18,7 @@ if (test-path env:SEARCH) {
 $dcos_nets_up = @()
 $NAME_SERVERS | ForEach-Object {
     try {
-        Resolve-DnsName $dns_test_query -server $_
+        Resolve-DnsName $dns_test_query -server $_ -ErrorAction Stop
 
         # if successful add it to the list
         $dcos_nets_up += $_


### PR DESCRIPTION
Without this one, the PowerShell cmdlet `Resolve-DnsName` doesn't generate an exception to be caught by the `try / catch` block.
